### PR TITLE
Pin vcpu to physical cpu. Reduce to 1 cpu

### DIFF
--- a/usr/share/whonix-libvirt/xml/Whonix-Workstation.xml
+++ b/usr/share/whonix-libvirt/xml/Whonix-Workstation.xml
@@ -3,7 +3,7 @@
   <description>Do not change any settings if you do not understand the consequences! Learn more: https://www.whonix.org/wiki/KVM#XML_Settings</description>
   <memory unit='KiB'>1048576</memory>
   <currentMemory unit='KiB'>1048576</currentMemory>
-  <vcpu placement='static'>2</vcpu>
+  <vcpu placement='static' cpuset='1'>1</vcpu>
   <os>
     <type>hvm</type>
     <boot dev='hd'/>


### PR DESCRIPTION
Makes some covert channel attacks more difficult. Eliminates cross-VM cache attacks on crypto.
