### PR TITLE
attack surface reduction

### DIFF
--- a/usr/share/whonix-libvirt/xml/Whonix-Custom-Workstation.xml
+++ b/usr/share/whonix-libvirt/xml/Whonix-Custom-Workstation.xml
@@ -2,6 +2,9 @@
   <name>Whonix-Custom-Workstation</name>
   <description>Do not change any settings if you do not understand the consequences! Learn more: https://www.whonix.org/wiki/KVM#XML_Settings</description>
   <memory unit='KiB'>1048576</memory>
+  <memoryBacking>
+   <nosharepages/>
+  </memoryBacking>
   <currentMemory unit='KiB'>1048576</currentMemory>
   <vcpu placement='static' cpuset='1'>1</vcpu>
   <os>
@@ -9,11 +12,8 @@
     <boot dev='hd'/>
   </os>
   <features>
-    <acpi/>
-    <apic eoi='on'/>
-    <pae/>
     <hap/>
-    <pvspinlock/>
+    <pvspinlock state='off'/>
   </features>
   <cpu mode='custom' match='exact'>
     <model fallback='forbid'>qemu64</model>
@@ -23,7 +23,7 @@
     <feature policy='optional' name='aes'/>
   </cpu>
   <clock offset='utc'>
-    <timer name='rtc' tickpolicy='catchup' track='guest'/>
+    <timer name='rtc' present='no'/>
     <timer name='kvmclock' present='no'/>
     <timer name='pit' present='no'/>
     <timer name='hpet' present='no'/>


### PR DESCRIPTION
Disabled (for attack surface reduction):
- rtc and acpi_pm timers leaving the coarse and inaccurate jiffies and refined_jiffes internal counters as the only guest source.
- (explicitly) mem dedupe in case host is silly enough to have it enabled.
- pae
- apic
- acpi
- pvspinlock because we don't want multithreading
