### PR TITLE
attack surface reduction

### DIFF
--- a/usr/share/whonix-libvirt/xml/Whonix-Gateway.xml
+++ b/usr/share/whonix-libvirt/xml/Whonix-Gateway.xml
@@ -2,6 +2,9 @@
   <name>Whonix-Gateway</name>
   <description>Do not change any settings if you do not understand the consequences! Learn more: https://www.whonix.org/wiki/KVM#XML_Settings</description>
   <memory unit='KiB'>524288</memory>
+  <memoryBacking>
+   <nosharepages/>
+  </memoryBacking>
   <currentMemory unit='KiB'>524288</currentMemory>
   <vcpu placement='static' cpuset='0'>1</vcpu>
   <os>
@@ -10,8 +13,6 @@
   </os>
   <features>
     <acpi/>
-    <apic eoi='on'/>
-    <pae/>
     <hap/>
     <pvspinlock/>
   </features>


### PR DESCRIPTION
Disabled (for attack surface reduction):

Rest of changes irrelevant for trusted GW.
- (explicitly) mem dedupe in case host is silly enough to have it enabled.
- pae
- apic
