### PR TITLE
Rate limit RNG

### DIFF
--- a/usr/share/whonix-libvirt/xml/Whonix-Workstation.xml
+++ b/usr/share/whonix-libvirt/xml/Whonix-Workstation.xml
@@ -61,6 +61,7 @@
     </video>
     <memballoon model='none'/>
     <rng model='virtio'>
+      <rate bytes='1024' period='1000'/>
       <backend model='random'>/dev/random</backend>
     </rng>
   </devices>


### PR DESCRIPTION
This is necessary to prevent malicious entropy starvation of other VMs and the host.

https://www.certdepot.net/rhel7-get-started-random-number-generator/
