### PR TITLE
Update packages.conf.whonix

### DIFF
--- a/etc/calamares/modules/packages.conf.whonix
+++ b/etc/calamares/modules/packages.conf.whonix
@@ -2,11 +2,6 @@ backend: apt
 
 operations:
    - remove:
-      - 'live-boot'
-      - 'live-config'
-      - 'live-config-systemd'
-      - 'live-config-systemd'
-      - 'live-tools'
       - 'calamares'
       - 'calamares-settings-debian'
 EOF

--- a/etc/calamares/modules/packages.conf.whonix
+++ b/etc/calamares/modules/packages.conf.whonix
@@ -2,6 +2,7 @@ backend: apt
 
 operations:
    - remove:
+      - 'live-config'
       - 'calamares'
       - 'calamares-settings-debian'
 EOF


### PR DESCRIPTION
Removing live-boot packages from the list of deleted packages on the install target. Allows the install target to boot in live-mode (also: fixes the issue when "Debian-Live" grub entry results in a kernel panic).