### PR TITLE
Update packages.conf.whonix

### DIFF
--- a/etc/calamares/modules/packages.conf.whonix
+++ b/etc/calamares/modules/packages.conf.whonix
@@ -2,7 +2,6 @@ backend: apt
 
 operations:
    - remove:
-      - 'live-config'
       - 'calamares'
       - 'calamares-settings-debian'
 EOF


### PR DESCRIPTION
Remove 'live-config' as it is no longer installed in the iso file. Breaks Calamares install otherwise.