### PR TITLE
Create settings.conf

### DIFF
--- a/etc/calamares/settings.conf
+++ b/etc/calamares/settings.conf
@@ -1,0 +1,89 @@
+# Configuration file for Calamares
+# Syntax is YAML 1.2
+---
+
+# "local" is LIBDIR/calamares/modules with settings in SHARE/calamares/modules
+modules-search: [ local, /usr/lib/calamares/modules ]
+
+sequence:
+
+# Phase 1 - prepare.
+# View modules are shown as UI pages, jobs from job modules
+# are executed immediately in the background.
+# Jobs should be executed sparingly (if at all) in this phase.
+- show:
+  - welcome
+  - locale
+  - keyboard
+  - partition
+  - summary
+
+# Phase 2 - install.
+# View modules are not shown. Only the view modules shown
+# in the previous phase are allowed, their names should be
+# added here as placeholders to specify the order in which
+# view module jobs should be enqueued. Job modules are
+# also allowed.
+- exec:
+  - partition
+  - mount
+  - unpackfs
+  - sources-media
+  - machineid
+  - fstab
+  - locale
+  - keyboard
+  - localecfg
+  - networkcfg
+  - hwclock
+  - services-systemd
+  - bootloader-config
+  - grubcfg
+  - bootloader
+  - packages
+  - luksbootkeyfile
+  - plymouthcfg
+  - initramfscfg
+  - initramfs
+  - sources-media-unmount
+  - sources-final
+  - umount
+
+# Phase 3 - postinstall.
+# View modules are shown as UI pages, jobs from job modules are
+# executed immediately in the background.
+# Jobs should be executed sparingly (if at all) in this phase.
+- show:
+  - finished
+
+# A branding component is a directory, either in
+# SHARE/calamares/branding or in /etc/calamares/branding
+# (the latter takes precedence). The directory must contain a
+# YAML file branding.desc which may reference additional resources
+# (such as images) as paths relative to the current directory.
+# Only the name of the branding component (directory) should be
+# specified here, Calamares then takes care of finding it and
+# loading the contents.
+branding: debian
+
+# If this is set to true, Calamares will show an "Are you sure?" prompt right
+# before each execution phase, i.e. at points of no return. If this is set to
+# false, no prompt is shown. Default is false.
+#
+# YAML: boolean.
+prompt-install: false
+
+# If this is set to true, Calamares will execute all target environment
+# commands in the current environment, without chroot. This setting should
+# only be used when setting up Calamares as a post-install configuration tool,
+# as opposed to a full operating system installer.
+#
+# Some official Calamares modules are not expected to function with this
+# setting. (e.g. partitioning seems like a bad idea, since that is expected to
+# have been done already)
+#
+# Default is false (for a normal installer).
+#
+# YAML: boolean.
+dont-chroot: false
+


### PR DESCRIPTION
Modified settings.conf for Calamares removing the 'users' modules from the Calamares install sequence. Reason: we do not want to install a user, user 'user' is the default user. See https://forums.whonix.org/t/whonix-host-operating-system/3931/134