### PR TITLE
Whonix-Workstation KVM 3D acceleration configs

### DIFF
--- a/usr/share/libvirt-dist/xml/Whonix-Gateway.xml
+++ b/usr/share/libvirt-dist/xml/Whonix-Gateway.xml
@@ -2,8 +2,8 @@
   <name>Whonix-Gateway</name>
   <description>Do not change any settings if you do not understand the consequences! Learn more: https://www.whonix.org/wiki/KVM#XML_Settings</description>
   <genid/>
-  <memory dumpCore='off' unit='KiB'>1250000</memory>
-  <currentMemory unit='KiB'>1250000</currentMemory>
+  <memory dumpCore='off' unit='KiB'>1310720</memory>
+  <currentMemory unit='KiB'>1310720</currentMemory>
   <memoryBacking>
     <allocation mode='ondemand'/>
     <discard/>

--- a/usr/share/libvirt-dist/xml/Whonix-Workstation.xml
+++ b/usr/share/libvirt-dist/xml/Whonix-Workstation.xml
@@ -16,6 +16,7 @@
   <os>
     <type machine='q35'>hvm</type>
     <boot dev='hd'/>
+    <bootmenu enable='yes'/>
   </os>
   <features>
     <acpi/>
@@ -61,17 +62,25 @@
       <target type='virtio' name='com.redhat.spice.0'/>
       <address type='virtio-serial' controller='0' bus='0' port='1'/>
     </channel>
+    
+    <!-- Graphics settings -->
     <graphics type='spice' autoport='yes'>
+      <listen type='none'/>
       <clipboard copypaste='no'/>
       <filetransfer enable='no'/>
       <gl enable='no'/>
     </graphics>
+
+    <!-- Video settings -->
+    <video>
+      <model type='virtio' heads='1' primary='yes'>
+        <acceleration accel3d='no'/>
+      </model>
+    </video>
+    
     <sound model='ich9'>
       <codec type='output'/>
     </sound>
-    <video>
-      <model type='virtio' heads='1' primary='yes'/>
-    </video>
     <memballoon model='none'/>
     <rng model='virtio'>
       <rate bytes='1024' period='1000'/>

--- a/usr/share/libvirt-dist/xml/Whonix-Workstation.xml
+++ b/usr/share/libvirt-dist/xml/Whonix-Workstation.xml
@@ -2,8 +2,8 @@
   <name>Whonix-Workstation</name>
   <description>Do not change any settings if you do not understand the consequences! Learn more: https://www.whonix.org/wiki/KVM#XML_Settings</description>
   <genid/>
-  <memory dumpCore='off' unit='KiB'>2000000</memory>
-  <currentMemory unit='KiB'>2000000</currentMemory>
+  <memory dumpCore='off' unit='KiB'>2097152</memory>
+  <currentMemory unit='KiB'>2097152</currentMemory>
   <memoryBacking>
     <allocation mode='ondemand'/>
     <discard/>


### PR DESCRIPTION
This pull request changes...

## Changes

- SPICE video: listen to none (which mean locally only) by default.

- Added 3d acceleration but disabled.

- Added OpenGL but disabled.

- Added user readable commits.

- Enabled KVM bootmenu for easy ISO recovery when used.

- Adjusted RAM KBs to represent 2 exact GB.

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
