### PR TITLE
Update Whonix-Workstation.xml to use GB

### DIFF
--- a/usr/share/libvirt-dist/xml/Whonix-Workstation.xml
+++ b/usr/share/libvirt-dist/xml/Whonix-Workstation.xml
@@ -2,8 +2,8 @@
   <name>Whonix-Workstation</name>
   <description>Do not change any settings if you do not understand the consequences! Learn more: https://www.whonix.org/wiki/KVM#XML_Settings</description>
   <genid/>
-  <memory dumpCore='off' unit='KiB'>2097152</memory>
-  <currentMemory unit='KiB'>2097152</currentMemory>
+  <memory dumpCore='off' unit='GB'>2</memory>
+  <currentMemory unit='GB'>2</currentMemory>
   <memoryBacking>
     <allocation mode='ondemand'/>
     <discard/>


### PR DESCRIPTION


This pull request changes...

## Changes

- Using GB by default instead of MB

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [ ] I have tested it locally
- [ ] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
