### PR TITLE
Update Whonix-Gateway.plist.template

### DIFF
--- a/usr/share/utm/Whonix-Gateway.plist.template
+++ b/usr/share/utm/Whonix-Gateway.plist.template
@@ -27,7 +27,7 @@
 			<key>Identifier</key>
 			<string>0</string>
 			<key>ImageName</key>
-			<string>Whonix-Gateway-Xfce.raw</string>
+			<string>_FLAVOR_.raw</string>
 			<key>ImageType</key>
 			<string>Disk</string>
 			<key>Interface</key>
@@ -43,7 +43,7 @@
 		<key>IconCustom</key>
 		<false/>
 		<key>Name</key>
-		<string>Whonix-Gateway-Xfce</string>
+		<string>_FLAVOR_</string>
 		<key>UUID</key>
 		<string>2C279BF0-E968-4EF1-B93E-61BABD03A7B7</string>
 	</dict>


### PR DESCRIPTION
Should the user decide to build Whonix-Gateway-CLI instead of Whonix-Gateway-Xfce, this template wouldn't work. I propose using `_FLAVOR_` to account for user choice. I made a pull request [here](https://github.com/Whonix/derivative-maker/pull/11) as well. NOTE: should this be approved, this should be synchronous with the other PR.

This pull request changes...

## Changes

## Mandatory Checklist

- [x] Legal agreements accepted. By contributing to this organisation, you acknowledge you have read, understood, and agree to be bound by these these agreements:

[Terms of Service](https://www.kicksecure.com/wiki/Terms_of_Service), [Privacy Policy](https://www.kicksecure.com/wiki/Privacy_Policy), [Cookie Policy](https://www.kicksecure.com/wiki/Cookie_Policy), [E-Sign Consent](https://www.kicksecure.com/wiki/E-Sign_Consent), [DMCA](https://www.kicksecure.com/wiki/DMCA), [Imprint](https://www.kicksecure.com/wiki/Imprint)

## Optional Checklist
The following items are optional but might be requested in certain cases.

- [x] I have tested it locally
- [x] I have reviewed and updated any documentation if relevant
- [ ] I am providing new code and test(s) for it

Fixes #
